### PR TITLE
Fix issue of iterating through sensitive variable

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -39,7 +39,7 @@ resource "aws_acm_certificate" "this" {
 resource "aws_route53_record" "this" {
   provider = aws.route53
 
-  for_each = local.cert_domain_records
+  for_each = nonsensitive(local.cert_domain_records)
 
   allow_overwrite = var.route53_allow_overwrite
 
@@ -51,7 +51,7 @@ resource "aws_route53_record" "this" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  count = length(local.cert_domain_records) > 0 ? 1 : 0
+  count = length(nonsensitive(local.cert_domain_records)) > 0 ? 1 : 0
 
   certificate_arn         = aws_acm_certificate.this.arn
   validation_record_fqdns = values(aws_route53_record.this).*.fqdn


### PR DESCRIPTION
while using the module i encountered the enxt issue
![image](https://user-images.githubusercontent.com/3071208/137705504-0b97cdbb-5132-4ad6-a7b2-f521a398fc06.png)
this is cause by using a foreach on data marked as sensitive to disable this behaviour and keep backward compatibility i have used https://www.terraform.io/docs/language/functions/nonsensitive.html functionality